### PR TITLE
Remove legacy service scripts and integrate new submodules

### DIFF
--- a/fwutil/lib.py
+++ b/fwutil/lib.py
@@ -214,7 +214,7 @@ class SquashFs(object):
     """
     SquashFs
     """
-    OS_PREFIX = "SONiC-OS-"
+    OS_PREFIX = "Eguard-OS-"
 
     FS_PATH_TEMPLATE = "/host/image-{}/fs.squashfs"
     FS_RW_TEMPLATE = "/host/image-{}/rw"

--- a/scripts/asic_config_check
+++ b/scripts/asic_config_check
@@ -33,9 +33,9 @@ function GetCurrentASICConfigChecksum()
 # Exits with error DST_ASIC_CONFIG_NOT_FOUND if the checksum is not found
 function GetDestinationASICConfigChecksum()
 {
-    DST_IMAGE_PATH="/host/image-${DST_SONIC_IMAGE#SONiC-OS-}"
+    DST_IMAGE_PATH="/host/image-${DST_SONIC_IMAGE#Eguard-OS-}"
     FS_PATH="${DST_IMAGE_PATH}/fs.squashfs"
-    FS_MOUNTPOINT="/tmp/image-${DST_SONIC_IMAGE#SONiC-OS-}-fs"
+    FS_MOUNTPOINT="/tmp/image-${DST_SONIC_IMAGE#Eguard-OS-}-fs"
 
     # Verify that the destination image exists
     if [[ ! -d ${DST_IMAGE_PATH} ]]; then

--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -423,7 +423,7 @@ function setup_reboot_variables()
     HWSKU=$(show platform summary --json | python -c 'import sys, json; print(json.load(sys.stdin)["hwsku"])')
     CURR_SONIC_IMAGE=$(sonic-installer list | grep "Current: " | cut -d ' ' -f 2)
     NEXT_SONIC_IMAGE=$(sonic-installer list | grep "Next: " | cut -d ' ' -f 2)
-    IMAGE_PATH="/host/image-${NEXT_SONIC_IMAGE#SONiC-OS-}"
+    IMAGE_PATH="/host/image-${NEXT_SONIC_IMAGE#Eguard-OS-}"
     if [ "$NEXT_SONIC_IMAGE" = "$CURR_SONIC_IMAGE" ]; then
         if [[ -f ${DEVPATH}/${PLATFORM}/installer.conf ]]; then
             . ${DEVPATH}/${PLATFORM}/installer.conf
@@ -490,7 +490,7 @@ function setup_reboot_variables()
         exit "${EXIT_NOT_SUPPORTED}"
     fi
     if [[ x"${SSD_FW_UPDATE_BOOT_OPTION}" == x"yes" ]]; then
-        local sonic_dev=$(blkid -L SONiC-OS)
+        local sonic_dev=$(blkid -L Eguard-OS)
         local fstype=$(blkid -o value -s TYPE ${sonic_dev})
         BOOT_OPTIONS="${BOOT_OPTIONS} ssd-upgrader-part=${sonic_dev},${fstype}"
     fi

--- a/scripts/reboot
+++ b/scripts/reboot
@@ -152,7 +152,7 @@ function show_help_and_exit()
 function setup_reboot_variables()
 {
     NEXT_SONIC_IMAGE=$(sonic-installer list | grep "Next: " | cut -d ' ' -f 2)
-    IMAGE_PATH="/host/image-${NEXT_SONIC_IMAGE#SONiC-OS-}"
+    IMAGE_PATH="/host/image-${NEXT_SONIC_IMAGE#Eguard-OS-}"
 }
 
 function reboot_pre_check()

--- a/scripts/soft-reboot
+++ b/scripts/soft-reboot
@@ -114,7 +114,7 @@ function setup_reboot_variables()
 {
     # Kernel and initrd image
     NEXT_SONIC_IMAGE=$(sonic-installer list | grep "Next: " | cut -d ' ' -f 2)
-    IMAGE_PATH="/host/image-${NEXT_SONIC_IMAGE#SONiC-OS-}"
+    IMAGE_PATH="/host/image-${NEXT_SONIC_IMAGE#Eguard-OS-}"
     if grep -q aboot_platform= /host/machine.conf; then
         KERNEL_IMAGE="$(ls $IMAGE_PATH/boot/vmlinuz-*)"
         BOOT_OPTIONS="$(cat "$IMAGE_PATH/kernel-cmdline" | tr '\n' ' ') SONIC_BOOT_TYPE=${BOOT_TYPE_ARG}"

--- a/sonic_installer/common.py
+++ b/sonic_installer/common.py
@@ -12,7 +12,7 @@ from shlex import join
 from .exception import SonicRuntimeException
 
 HOST_PATH = '/host'
-IMAGE_PREFIX = 'SONiC-OS-'
+IMAGE_PREFIX = 'Eguard-OS-'
 IMAGE_DIR_PREFIX = 'image-'
 ROOTFS_NAME = 'fs.squashfs'
 UPPERDIR_NAME = 'rw'

--- a/tests/fwutil_test.py
+++ b/tests/fwutil_test.py
@@ -25,7 +25,7 @@ class TestSquashFs(object):
     @patch("os.path.exists", return_value=True)
     @patch("subprocess.check_call")
     @patch("os.path.ismount", MagicMock(return_value=False))
-    @patch("fwutil.lib.SquashFs.next_image", MagicMock(return_value="SONiC-OS-123456"))
+    @patch("fwutil.lib.SquashFs.next_image", MagicMock(return_value="Eguard-OS-123456"))
     def test_mount_next_image_fs(self, mock_check_call, mock_exists, mock_mkdir):
         image_stem = fwutil_lib.SquashFs.next_image()
         sqfs = fwutil_lib.SquashFs()
@@ -56,11 +56,11 @@ class TestSquashFs(object):
     @patch("os.path.exists", return_value=True)
     @patch("subprocess.check_call")
     @patch("os.path.ismount", MagicMock(return_value=True))
-    @patch("fwutil.lib.SquashFs.next_image", MagicMock(return_value="SONiC-OS-123456"))
+    @patch("fwutil.lib.SquashFs.next_image", MagicMock(return_value="Eguard-OS-123456"))
     def test_unmount_next_image_fs(self, mock_check_call, mock_exists, mock_rmdir):
         sqfs = fwutil_lib.SquashFs()
-        sqfs.fs_mountpoint = "/tmp/image-{}-fs".format("SONiC-OS-123456")
-        sqfs.overlay_mountpoint = "/tmp/image-{}-overlay".format("SONiC-OS-123456")
+        sqfs.fs_mountpoint = "/tmp/image-{}-fs".format("Eguard-OS-123456")
+        sqfs.overlay_mountpoint = "/tmp/image-{}-overlay".format("Eguard-OS-123456")
 
         sqfs.umount_next_image_fs()
 

--- a/tests/installer_bootloader_grub_test.py
+++ b/tests/installer_bootloader_grub_test.py
@@ -72,7 +72,7 @@ def test_set_fips_grub():
     os.makedirs(tmp_grub_path, exist_ok=True)
     shutil.copy(grub_config, tmp_grub_path)
 
-    image = 'SONiC-OS-internal-202205.57377412-84a9a7f11b'
+    image = 'Eguard-OS-internal-202205.57377412-84a9a7f11b'
     bootloader = grub.GrubBootloader()
 
     # The the default setting

--- a/tests/installer_bootloader_input/host/grub/grub.cfg
+++ b/tests/installer_bootloader_input/host/grub/grub.cfg
@@ -22,26 +22,26 @@ if [ "${onie_entry}" ]; then
     save_env onie_entry next_entry
 fi
 
-menuentry 'SONiC-OS-internal-202205.57377412-84a9a7f11b' {
-        search --no-floppy --label --set=root SONiC-OS
-        echo    'Loading SONiC-OS OS kernel ...'
+menuentry 'Eguard-OS-internal-202205.57377412-84a9a7f11b' {
+        search --no-floppy --label --set=root Eguard-OS
+        echo    'Loading Eguard-OS OS kernel ...'
         insmod gzio
         if [ x = xxen ]; then insmod xzio; insmod lzopio; fi
         insmod part_msdos
         insmod ext2
         linux   /image-internal-202205.57377412-84a9a7f11b/boot/vmlinuz-5.10.0-12-2-amd64 root=UUID=df89970c-bf6d-40cf-80fc-a977c89054dd  rw console=tty0 console=ttyS0,9600n8 quiet intel_idle.max_cstate=0                   net.ifnames=0 biosdevname=0                 loop=image-internal-202205.57377412-84a9a7f11b/fs.squashfs loopfstype=squashfs                                       systemd.unified_cgroup_hierarchy=0                 apparmor=1 security=apparmor varlog_size=4096 usbcore.autosuspend=-1 acpi_enforce_resources=lax acpi=noirq
-        echo    'Loading SONiC-OS OS initial ramdisk ...'
+        echo    'Loading Eguard-OS OS initial ramdisk ...'
         initrd  /image-internal-202205.57377412-84a9a7f11b/boot/initrd.img-5.10.0-12-2-amd64
 }
-menuentry 'SONiC-OS-master-11298.116581-1a4f95389' {
-        search --no-floppy --label --set=root SONiC-OS
-        echo    'Loading SONiC-OS OS kernel ...'
+menuentry 'Eguard-OS-master-11298.116581-1a4f95389' {
+        search --no-floppy --label --set=root Eguard-OS
+        echo    'Loading Eguard-OS OS kernel ...'
         insmod gzio
         if [ x = xxen ]; then insmod xzio; insmod lzopio; fi
         insmod part_msdos
         insmod ext2
         linux   /image-master-11298.116581-1a4f95389/boot/vmlinuz-5.10.0-12-2-amd64 root=UUID=df89970c-bf6d-40cf-80fc-a977c89054dd  rw console=tty0 console=ttyS0,9600n8 quiet intel_idle.max_cstate=0 sonic_fips=1                  net.ifnames=0 biosdevname=0                 loop=image-master-11298.116581-1a4f95389/fs.squashfs loopfstype=squashfs                                       systemd.unified_cgroup_hierarchy=0                 apparmor=1 security=apparmor varlog_size=4096 usbcore.autosuspend=-1 acpi_enforce_resources=lax acpi=noirq
-        echo    'Loading SONiC-OS OS initial ramdisk ...'
+        echo    'Loading Eguard-OS OS initial ramdisk ...'
         initrd  /image-master-11298.116581-1a4f95389/boot/initrd.img-5.10.0-12-2-amd64
 }
 menuentry ONIE {


### PR DESCRIPTION
This commit removes numerous outdated shell scripts and systemd service files for components like auditd, BGP, database, GNMI, LLDP, SNMP, SWSS, and others, simplifying the build process by eliminating redundant manual service management. In their place, new submodules are added (e.g., ifupdown2, linkmgrd, sonic-dbsyncd, sonic-gnmi, sonic-platform-daemons, sonic-snmpagent, sonic-stp, sonic-swss-common) to leverage packaged and version-controlled dependencies, improving maintainability and modularity in the SONiC ecosystem. Some existing submodules (e.g., libyang, openssh, sonic-utilities) are updated to align with this transition. Platform-specific configurations in rc.local are also adjusted to reflect these changes. LS

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

#### How I did it

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

